### PR TITLE
Add support for OUTPUT Sensors

### DIFF
--- a/DCCpp_Uno/Sensor.h
+++ b/DCCpp_Uno/Sensor.h
@@ -17,6 +17,7 @@ Part of DCC++ BASE STATION for the Arduino Uno
 struct SensorData {
   int snum;
   byte pin;
+  boolean dir;
   byte pullUp;
 };
 
@@ -28,13 +29,15 @@ struct Sensor{
   Sensor *nextSensor;
   static void load();
   static void store();
+  static Sensor *create(int, int, int, int, int);
   static Sensor *create(int, int, int, int=0);
   static Sensor* get(int);  
   static void remove(int);  
   static void show();
   static void status();
   static void parse(char *c);
-  static void check();   
+  static void check();
+  static void write(int, int);
 }; // Sensor
 
 #endif


### PR DESCRIPTION
Ok, if it’s an output it’s not really a Sensor, but…
Allows definition of a Sensor with direction OUTPUT, and adds a Write
command to change its state.  

Commands:
<S ID PIN DIR PULLUP>  : Define an output or input pin.   Responses: <O> or <X>
<S ID PIN PULLUP>  : Define an input pin (same as before) Responses: <O> or <X>
<S ID VAL> : Write a value to an output pin. Ignored if pin not defined as OUTPUT: No (direct) response.
<S ID> : Delete a Sensor Responses: <O> or <X>
<S> : List sensors.  Responses: <Q ID PIN DIR PULLUP> or <X>

The Write command doesn't have a direct response, but the state change of the pin will trigger a <Q/q ID> message anyway.