### PR TITLE
Fix typos and newlines

### DIFF
--- a/DCCpp_Uno/CurrentMonitor.cpp
+++ b/DCCpp_Uno/CurrentMonitor.cpp
@@ -31,9 +31,8 @@ void CurrentMonitor::check(){
   if(current>CURRENT_SAMPLE_MAX && digitalRead(SIGNAL_ENABLE_PIN_PROG)==HIGH){                    // current overload and Prog Signal is on (or could have checked Main Signal, since both are always on or off together)
     digitalWrite(SIGNAL_ENABLE_PIN_PROG,LOW);                                                     // disable both Motor Shield Channels
     digitalWrite(SIGNAL_ENABLE_PIN_MAIN,LOW);                                                     // regardless of which caused current overload
-    INTERFACE.print(msg);                                                                            // print corresponding error message
+    INTERFACE.print(msg);                                                                         // print corresponding error message
   }    
 } // CurrentMonitor::check  
 
 long int CurrentMonitor::sampleTime=0;
-

--- a/DCCpp_Uno/DCCpp_Uno.ino
+++ b/DCCpp_Uno/DCCpp_Uno.ino
@@ -424,13 +424,13 @@ void setup(){
 
 #define DCC_SIGNAL(R,N) \
   if(R.currentBit==R.currentReg->activePacket->nBits){    /* IF no more bits in this DCC Packet */ \
-    R.currentBit=0;                                       /*   reset current bit pointer and determine which Register and Packet to process next--- */ \   
+    R.currentBit=0;                                       /*   reset current bit pointer and determine which Register and Packet to process next--- */ \
     if(R.nRepeat>0 && R.currentReg==R.reg){               /*   IF current Register is first Register AND should be repeated */ \
       R.nRepeat--;                                        /*     decrement repeat count; result is this same Packet will be repeated */ \
     } else if(R.nextReg!=NULL){                           /*   ELSE IF another Register has been updated */ \
       R.currentReg=R.nextReg;                             /*     update currentReg to nextReg */ \
       R.nextReg=NULL;                                     /*     reset nextReg to NULL */ \
-      R.tempPacket=R.currentReg->activePacket;            /*     flip active and update Packets */ \        
+      R.tempPacket=R.currentReg->activePacket;            /*     flip active and update Packets */ \
       R.currentReg->activePacket=R.currentReg->updatePacket; \
       R.currentReg->updatePacket=R.tempPacket; \
     } else{                                               /*   ELSE simply move to next Register */ \
@@ -446,8 +446,8 @@ void setup(){
   } else{                                                                              /* ELSE it is a ZERO */ \
     OCR ## N ## A=DCC_ZERO_BIT_TOTAL_DURATION_TIMER ## N;                              /*   set OCRA for timer N to full cycle duration of DCC ZERO bit */ \
     OCR ## N ## B=DCC_ZERO_BIT_PULSE_DURATION_TIMER ## N;                              /*   set OCRB for timer N to half cycle duration of DCC ZERO bit */ \
-  }                                                                                    /* END-ELSE */ \ 
-                                                                                       \ 
+  }                                                                                    /* END-ELSE */ \
+                                                                                       \
   R.currentBit++;                                         /* point to next bit in current Packet */  
   
 ///////////////////////////////////////////////////////////////////////////////
@@ -557,7 +557,3 @@ void showConfiguration(){
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-
-
-
-

--- a/DCCpp_Uno/DCCpp_Uno.ino
+++ b/DCCpp_Uno/DCCpp_Uno.ino
@@ -202,7 +202,7 @@ CurrentMonitor progMonitor(CURRENT_MONITOR_PIN_PROG,"<p3>");  // create monitor 
 
 void loop(){
   
-  SerialCommand::process();              // check for, and process, and new serial commands
+  SerialCommand::process();              // check for, and process, any new serial commands
   
   if(CurrentMonitor::checkTime()){      // if sufficient time has elapsed since last update, check current draw on Main and Program Tracks 
     mainMonitor.check();
@@ -227,14 +227,14 @@ void setup(){
     digitalWrite(SDCARD_CS,HIGH);     // Deselect the SD card
   #endif
 
-  EEStore::init();                                          // initialize and load Turnout and Sensor definitions stored in EEPROM
+  EEStore::init();                                          // initialize and load Accessory (Turnout), Output, and Sensor definitions stored in EEPROM
 
   pinMode(A5,INPUT);                                       // if pin A5 is grounded upon start-up, print system configuration and halt
   digitalWrite(A5,HIGH);
   if(!digitalRead(A5))
     showConfiguration();
 
-  Serial.print("<iDCC++ BASE STATION FOR ARDUINO ");      // Print Status to Serial Line regardless of COMM_TYPE setting so use can open Serial Monitor and check configurtion 
+  Serial.print("<iDCC++ BASE STATION FOR ARDUINO ");      // Print Status to Serial Line regardless of COMM_TYPE setting so user can open Serial Monitor and check configurtion 
   Serial.print(ARDUINO_TYPE);
   Serial.print(" / ");
   Serial.print(MOTOR_SHIELD_NAME);

--- a/DCCpp_Uno/EEStore.cpp
+++ b/DCCpp_Uno/EEStore.cpp
@@ -24,7 +24,7 @@ void EEStore::init(){
   EEPROM.get(0,eeStore->data);                                       // get eeStore data 
   
   if(strncmp(eeStore->data.id,EESTORE_ID,sizeof(EESTORE_ID))!=0){    // check to see that eeStore contains valid DCC++ ID
-    sprintf(eeStore->data.id,EESTORE_ID);                           // if not, create blank eeStore structure (no turnouts, no sensors) and save it back to EEPROM
+    sprintf(eeStore->data.id,EESTORE_ID);                            // if not, create blank eeStore structure (no turnouts, no sensors, no outputs) and save it back to EEPROM
     eeStore->data.nTurnouts=0;
     eeStore->data.nSensors=0;
     eeStore->data.nOutputs=0;
@@ -42,7 +42,7 @@ void EEStore::init(){
 
 void EEStore::clear(){
     
-  sprintf(eeStore->data.id,EESTORE_ID);                           // create blank eeStore structure (no turnouts, no sensors) and save it back to EEPROM
+  sprintf(eeStore->data.id,EESTORE_ID);                              // create blank eeStore structure (no turnouts, no sensors, no outputs) and save it back to EEPROM
   eeStore->data.nTurnouts=0;
   eeStore->data.nSensors=0;
   eeStore->data.nOutputs=0;
@@ -80,4 +80,3 @@ int EEStore::pointer(){
 
 EEStore *EEStore::eeStore=NULL;
 int EEStore::eeAddress=0;
-

--- a/DCCpp_Uno/PacketRegister.cpp
+++ b/DCCpp_Uno/PacketRegister.cpp
@@ -43,9 +43,9 @@ RegisterList::RegisterList(int maxNumRegs){
 
 void RegisterList::loadPacket(int nReg, byte *b, int nBytes, int nRepeat, int printFlag) volatile {
   
-  nReg=nReg%((maxNumRegs+1));          // force nReg to be between 0 and maxNumRegs, inclusive
+  nReg=nReg%((maxNumRegs+1));         // force nReg to be between 0 and maxNumRegs, inclusive
 
-  while(nextReg!=NULL);              // pause while there is a Register already waiting to be updated -- nextReg will be reset to NULL by interrupt when prior Register updated fully processed
+  while(nextReg!=NULL);               // pause while there is a Register already waiting to be updated -- nextReg will be reset to NULL by interrupt when prior Register updated fully processed
  
   if(regMap[nReg]==NULL)              // first time this Register Number has been called
    regMap[nReg]=maxLoadedReg+1;       // set Register Pointer for this Register Number to next available Register
@@ -54,10 +54,10 @@ void RegisterList::loadPacket(int nReg, byte *b, int nBytes, int nRepeat, int pr
   Packet *p=r->updatePacket;          // set Packet in the Register to be updated
   byte *buf=p->buf;                   // set byte buffer in the Packet to be updated
           
-  b[nBytes]=b[0];                        // copy first byte into what will become the checksum byte  
-  for(int i=1;i<nBytes;i++)              // XOR remaining bytes into checksum byte
+  b[nBytes]=b[0];                     // copy first byte into what will become the checksum byte  
+  for(int i=1;i<nBytes;i++)           // XOR remaining bytes into checksum byte
     b[nBytes]^=b[i];
-  nBytes++;                              // increment number of bytes in packet to include checksum byte
+  nBytes++;                           // increment number of bytes in packet to include checksum byte
       
   buf[0]=0xFF;                        // first 8 bytes of 22-byte preamble
   buf[1]=0xFF;                        // second 8 bytes of 22-byte preamble
@@ -99,7 +99,7 @@ void RegisterList::loadPacket(int nReg, byte *b, int nBytes, int nRepeat, int pr
 ///////////////////////////////////////////////////////////////////////////////
 
 void RegisterList::setThrottle(char *s) volatile{
-  byte b[5];                      // save space for checksum byte
+  byte b[5];                          // save space for checksum byte
   int nReg;
   int cab;
   int tSpeed;
@@ -113,10 +113,10 @@ void RegisterList::setThrottle(char *s) volatile{
     return;  
 
   if(cab>127)
-    b[nB++]=highByte(cab) | 0xC0;      // convert train number into a two-byte address
+    b[nB++]=highByte(cab) | 0xC0;     // convert train number into a two-byte address
     
   b[nB++]=lowByte(cab);
-  b[nB++]=0x3F;                        // 128-step speed control byte
+  b[nB++]=0x3F;                       // 128-step speed control byte
   if(tSpeed>=0) 
     b[nB++]=tSpeed+(tSpeed>0)+tDirection*128;   // max speed is 126, but speed codes range from 2-127 (0=stop, 1=emergency stop)
   else{
@@ -139,7 +139,7 @@ void RegisterList::setThrottle(char *s) volatile{
 ///////////////////////////////////////////////////////////////////////////////
 
 void RegisterList::setFunction(char *s) volatile{
-  byte b[5];                      // save space for checksum byte
+  byte b[5];                          // save space for checksum byte
   int cab;
   int fByte, eByte;
   int nParams;
@@ -151,14 +151,14 @@ void RegisterList::setFunction(char *s) volatile{
     return;
 
   if(cab>127)
-    b[nB++]=highByte(cab) | 0xC0;      // convert train number into a two-byte address
+    b[nB++]=highByte(cab) | 0xC0;     // convert train number into a two-byte address
     
   b[nB++]=lowByte(cab);
 
-  if(nParams==2){                      // this is a request for functions FL,F1-F12  
-    b[nB++]=(fByte | 0x80) & 0xBF;     // for safety this guarantees that first nibble of function byte will always be of binary form 10XX which should always be the case for FL,F1-F12  
-  } else {                             // this is a request for functions F13-F28
-    b[nB++]=(fByte | 0xDE) & 0xDF;     // for safety this guarantees that first byte will either be 0xDE (for F13-F20) or 0xDF (for F21-F28)
+  if(nParams==2){                     // this is a request for functions FL,F1-F12  
+    b[nB++]=(fByte | 0x80) & 0xBF;    // for safety this guarantees that first nibble of function byte will always be of binary form 10XX which should always be the case for FL,F1-F12  
+  } else {                            // this is a request for functions F13-F28
+    b[nB++]=(fByte | 0xDE) & 0xDF;    // for safety this guarantees that first byte will either be 0xDE (for F13-F20) or 0xDF (for F21-F28)
     b[nB++]=eByte;
   }
     
@@ -169,16 +169,16 @@ void RegisterList::setFunction(char *s) volatile{
 ///////////////////////////////////////////////////////////////////////////////
 
 void RegisterList::setAccessory(char *s) volatile{
-  byte b[3];                      // save space for checksum byte
-  int aAdd;                       // the accessory address (0-511 = 9 bits) 
-  int aNum;                       // the accessory number within that address (0-3)
-  int activate;                   // flag indicated whether accessory should be activated (1) or deactivated (0) following NMRA recommended convention
+  byte b[3];                          // save space for checksum byte
+  int aAdd;                           // the accessory address (0-511 = 9 bits) 
+  int aNum;                           // the accessory number within that address (0-3)
+  int activate;                       // flag indicated whether accessory should be activated (1) or deactivated (0) following NMRA recommended convention
   
   if(sscanf(s,"%d %d %d",&aAdd,&aNum,&activate)!=3)
     return;
     
-  b[0]=aAdd%64+128;                                           // first byte is of the form 10AAAAAA, where AAAAAA represent 6 least signifcant bits of accessory address  
-  b[1]=((((aAdd/64)%8)<<4) + (aNum%4<<1) + activate%2) ^ 0xF8;      // second byte is of the form 1AAACDDD, where C should be 1, and the least significant D represent activate/deactivate
+  b[0]=aAdd%64+128;                                             // first byte is of the form 10AAAAAA, where AAAAAA represent 6 least signifcant bits of accessory address  
+  b[1]=((((aAdd/64)%8)<<4) + (aNum%4<<1) + activate%2) ^ 0xF8;  // second byte is of the form 1AAACDDD, where C should be 1, and the least significant D represent activate/deactivate
       
   loadPacket(0,b,2,4,1);
       
@@ -216,7 +216,7 @@ void RegisterList::readCV(char *s) volatile{
     return;    
   cv--;                              // actual CV addresses are cv-1 (0-1023)
   
-  bRead[0]=0x78+(highByte(cv)&0x03);   // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
+  bRead[0]=0x78+(highByte(cv)&0x03); // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
   bRead[1]=lowByte(cv);
   
   bValue=0;
@@ -254,7 +254,7 @@ void RegisterList::readCV(char *s) volatile{
     base+=analogRead(CURRENT_MONITOR_PIN_PROG);
   base/=ACK_BASE_COUNT;
   
-  bRead[0]=0x74+(highByte(cv)&0x03);   // set-up to re-verify entire byte
+  bRead[0]=0x74+(highByte(cv)&0x03);      // set-up to re-verify entire byte
   bRead[2]=bValue;  
 
   loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
@@ -292,7 +292,7 @@ void RegisterList::writeCVByte(char *s) volatile{
 
   if(sscanf(s,"%d %d %d %d",&cv,&bValue,&callBack,&callBackSub)!=4)          // cv = 1-1024
     return;    
-  cv--;                              // actual CV addresses are cv-1 (0-1023)
+  cv--;                                 // actual CV addresses are cv-1 (0-1023)
   
   bWrite[0]=0x7C+(highByte(cv)&0x03);   // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
   bWrite[1]=lowByte(cv);
@@ -311,7 +311,7 @@ void RegisterList::writeCVByte(char *s) volatile{
     base+=analogRead(CURRENT_MONITOR_PIN_PROG);
   base/=ACK_BASE_COUNT;
   
-  bWrite[0]=0x74+(highByte(cv)&0x03);   // set-up to re-verify entire byte
+  bWrite[0]=0x74+(highByte(cv)&0x03);     // set-up to re-verify entire byte
 
   loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
   loadPacket(0,bWrite,3,5);               // NMRA recommends 5 verfy packets
@@ -348,7 +348,7 @@ void RegisterList::writeCVBit(char *s) volatile{
 
   if(sscanf(s,"%d %d %d %d %d",&cv,&bNum,&bValue,&callBack,&callBackSub)!=5)          // cv = 1-1024
     return;    
-  cv--;                              // actual CV addresses are cv-1 (0-1023)
+  cv--;                                 // actual CV addresses are cv-1 (0-1023)
   bValue=bValue%2;
   bNum=bNum%8;
   
@@ -369,7 +369,7 @@ void RegisterList::writeCVBit(char *s) volatile{
     base+=analogRead(CURRENT_MONITOR_PIN_PROG);
   base/=ACK_BASE_COUNT;
   
-  bitClear(bWrite[2],4);              // change instruction code from Write Bit to Verify Bit
+  bitClear(bWrite[2],4);                  // change instruction code from Write Bit to Verify Bit
 
   loadPacket(0,resetPacket,2,3);          // NMRA recommends starting with 3 reset packets
   loadPacket(0,bWrite,3,5);               // NMRA recommends 5 verfy packets
@@ -401,7 +401,7 @@ void RegisterList::writeCVBit(char *s) volatile{
 ///////////////////////////////////////////////////////////////////////////////
 
 void RegisterList::writeCVByteMain(char *s) volatile{
-  byte b[6];                      // save space for checksum byte
+  byte b[6];                          // save space for checksum byte
   int cab;
   int cv;
   int bValue;
@@ -412,7 +412,7 @@ void RegisterList::writeCVByteMain(char *s) volatile{
   cv--;
 
   if(cab>127)    
-    b[nB++]=highByte(cab) | 0xC0;      // convert train number into a two-byte address
+    b[nB++]=highByte(cab) | 0xC0;     // convert train number into a two-byte address
     
   b[nB++]=lowByte(cab);
   b[nB++]=0xEC+(highByte(cv)&0x03);   // any CV>1023 will become modulus(1024) due to bit-mask of 0x03
@@ -426,7 +426,7 @@ void RegisterList::writeCVByteMain(char *s) volatile{
 ///////////////////////////////////////////////////////////////////////////////
 
 void RegisterList::writeCVBitMain(char *s) volatile{
-  byte b[6];                      // save space for checksum byte
+  byte b[6];                          // save space for checksum byte
   int cab;
   int cv;
   int bNum;
@@ -441,7 +441,7 @@ void RegisterList::writeCVBitMain(char *s) volatile{
   bNum=bNum%8; 
 
   if(cab>127)    
-    b[nB++]=highByte(cab) | 0xC0;      // convert train number into a two-byte address
+    b[nB++]=highByte(cab) | 0xC0;     // convert train number into a two-byte address
   
   b[nB++]=lowByte(cab);
   b[nB++]=0xE8+(highByte(cv)&0x03);   // any CV>1023 will become modulus(1024) due to bit-mask of 0x03

--- a/DCCpp_Uno/SerialCommand.cpp
+++ b/DCCpp_Uno/SerialCommand.cpp
@@ -47,11 +47,11 @@ void SerialCommand::process(){
     
   #if COMM_TYPE == 0
 
-    while(INTERFACE.available()>0){    // while there is data on the serial line
+    while(INTERFACE.available()>0){                       // while there is data on the serial line
      c=INTERFACE.read();
-     if(c=='<')                    // start of new command
+     if(c=='<')                                           // start of new command
        sprintf(commandString,"");
-     else if(c=='>')               // end of new command
+     else if(c=='>')                                      // end of new command
        parse(commandString);                    
      else if(strlen(commandString)<MAX_COMMAND_LENGTH)    // if comandString still has space, append character just read from serial line
        sprintf(commandString,"%s%c",commandString,c);     // otherwise, character is ignored (but continue to look for '<' or '>')
@@ -62,14 +62,14 @@ void SerialCommand::process(){
     EthernetClient client=INTERFACE.available();
 
     if(client){
-      while(client.connected() && client.available()){        // while there is data on the network
+      while(client.connected() && client.available()){    // while there is data on the network
       c=client.read();
-      if(c=='<')                    // start of new command
+      if(c=='<')                                          // start of new command
         sprintf(commandString,"");
-      else if(c=='>')               // end of new command
+      else if(c=='>')                                     // end of new command
         parse(commandString);                    
-      else if(strlen(commandString)<MAX_COMMAND_LENGTH)    // if comandString still has space, append character just read from network
-        sprintf(commandString,"%s%c",commandString,c);     // otherwise, character is ignored (but continue to look for '<' or '>')
+      else if(strlen(commandString)<MAX_COMMAND_LENGTH)   // if comandString still has space, append character just read from network
+        sprintf(commandString,"%s%c",commandString,c);    // otherwise, character is ignored (but continue to look for '<' or '>')
       } // while
     }
 
@@ -496,7 +496,7 @@ void SerialCommand::parse(char *com){
       mRegs->writeTextPacket(com+1);
       break;
 
-/***** WRITE A DCC PACKET TO ONE OF THE REGSITERS DRIVING THE MAIN OPERATIONS TRACK  ****/    
+/***** WRITE A DCC PACKET TO ONE OF THE REGSITERS DRIVING THE PROGRAMMING TRACK  ****/    
 
     case 'P':       // <P REGISTER BYTE1 BYTE2 [BYTE3] [BYTE4] [BYTE5]>
 /*
@@ -567,5 +567,3 @@ void SerialCommand::parse(char *com){
 }; // SerialCommand::parse
 
 ///////////////////////////////////////////////////////////////////////////////
-
-


### PR DESCRIPTION
This is a very minor cleanup of white space and typos.

The white space cleanup comes in 2 forms:
  1. Extraneous white-space after \ characters and before newlines
  2. Alignment of comments within a function and/or file. I did a number of changes here, but I didn't go crazy and align everything out to the longest possible line.

Additionally, some minor typos in the comments have been cleaned up; making it easier for someone who is looking at the code for the first time (ie Me as of a few days ago!) to more easily understand it.